### PR TITLE
First pass at PKCE support

### DIFF
--- a/classes/class-object-sync-sf-admin.php
+++ b/classes/class-object-sync-sf-admin.php
@@ -881,6 +881,19 @@ class Object_Sync_Sf_Admin {
 					'default'  => $this->default_token_url_path,
 				),
 			),
+			'pkce_support' => array(
+				'title'    => __( 'Support PKCE?', 'object-sync-for-salesforce' ),
+				'callback' => $callbacks['text'],
+				'page'     => $page,
+				'section'  => $section,
+				'args'     => array(
+					'type'     => 'checkbox',
+					'validate' => 'sanitize_text_field',
+					'desc'     => __( 'To improve the security of your OAuth and authentication provider implementations, Salesforce supports the OAuth 2.0 Proof Key for Code Exchange (PKCE) extension. Check this field if you wish to support this.', 'object-sync-for-salesforce' ),
+					'constant' => '',
+				),
+
+			),
 			'object_filters'                 => array(
 				'title'    => __( 'Limit Salesforce Objects', 'object-sync-for-salesforce' ),
 				'callback' => $callbacks['checkboxes'],

--- a/classes/class-object-sync-sf-salesforce.php
+++ b/classes/class-object-sync-sf-salesforce.php
@@ -1330,7 +1330,7 @@ class Object_Sync_Sf_Salesforce {
 	protected function get_challenge() {
 		$data = get_transient( $this->option_prefix . 'challenge', '' );
 
-		if ( $data ) {
+		if ( is_array( $data ) && isset( $data['verifier], $data['code'] ) ) {
 			return $data;
 		}
 

--- a/classes/class-object-sync-sf-salesforce.php
+++ b/classes/class-object-sync-sf-salesforce.php
@@ -1349,7 +1349,7 @@ class Object_Sync_Sf_Salesforce {
 
 	/**
 	 * Generate challenge verifier.
-	*/
+	 */
 	private function generate_challenge_verifier( $length = 128 ) {
 		$random_bytes = random_bytes( $length );
 		return rtrim( strtr( base64_encode( $random_bytes ), '+/', '-_' ), '=' );

--- a/classes/class-object-sync-sf-salesforce.php
+++ b/classes/class-object-sync-sf-salesforce.php
@@ -822,7 +822,7 @@ class Object_Sync_Sf_Salesforce {
 			$challenge = $this->get_challenge();
 
 			$url = add_query_arg( [
-				'code_challenge' => $challenge['code'] || '',
+				'code_challenge' => $challenge['code'] ?? '',
 				'code_challenge_method' => 'S256',
 			], $url );
 		}

--- a/classes/class-object-sync-sf-salesforce.php
+++ b/classes/class-object-sync-sf-salesforce.php
@@ -847,7 +847,7 @@ class Object_Sync_Sf_Salesforce {
 
 		if ( get_option( $this->option_prefix . 'pkce_support', false ) ) {
 			$challenge = $this->get_challenge();
-			$data['code_verifier'] = $challenge['verifier'] || '';
+			$data['code_verifier'] = $challenge['verifier'] ?? '';
 		}
 
 		$url      = $this->login_url . $this->token_path;

--- a/classes/class-object-sync-sf-salesforce.php
+++ b/classes/class-object-sync-sf-salesforce.php
@@ -817,6 +817,16 @@ class Object_Sync_Sf_Salesforce {
 			),
 			$this->login_url . $this->authorize_path
 		);
+
+		if ( get_option( $this->option_prefix . 'pkce_support', false ) ) {
+			$challenge = $this->get_challenge();
+
+			$url = add_query_arg( [
+				'code_challenge' => $challenge['code'] || '',
+				'code_challenge_method' => 'S256',
+			], $url );
+		}
+
 		return $url;
 	}
 
@@ -834,6 +844,11 @@ class Object_Sync_Sf_Salesforce {
 			'client_secret' => $this->consumer_secret,
 			'redirect_uri'  => $this->callback_url,
 		);
+
+		if ( get_option( $this->option_prefix . 'pkce_support', false ) ) {
+			$challenge = $this->get_challenge();
+			$data['code_verifier'] = $challenge['verifier'] || '';
+		}
 
 		$url      = $this->login_url . $this->token_path;
 		$headers  = array(
@@ -1308,4 +1323,45 @@ class Object_Sync_Sf_Salesforce {
 		return $cache_expiration;
 	}
 
+	/*
+	* Get challenge code and verifier.
+	* If no cached challenge data, generate a new verifier and challenge code and cache them.
+	*/
+	protected function get_challenge() {
+		$data = get_transient( $this->option_prefix . 'challenge', '' );
+
+		if ( $data ) {
+			return $data;
+		}
+
+		$verifier = $this->generate_challenge_verifier();
+		$code = $this->generate_challenge_code( $verifier );
+
+		$data = [
+			'verifier' => $verifier,
+			'code' => $code,
+		];
+
+		set_transient( $this->option_prefix . 'challenge', $data, 15 * MINUTE_IN_SECONDS );
+
+		return $data;
+	}
+
+	/**
+	 * Generate challenge verifier.
+	*/
+	private function generate_challenge_verifier( $length = 128 ) {
+		$random_bytes = random_bytes( $length );
+		return rtrim( strtr( base64_encode( $random_bytes ), '+/', '-_' ), '=' );
+	}
+
+	/**
+	 * Generate the challenge code for PKCE support. If no cached verifier generate a new one.
+	 *
+	 * @param string $challenge_verifier Challenge verifier.
+	 * @return void
+	 */
+	private function generate_challenge_code( $challenge_verifier ) {
+		return rtrim( strtr( base64_encode( hash( 'sha256', $challenge_verifier, true ) ), '+/', '-_' ), '=' );
+	}
 }


### PR DESCRIPTION
Our Salesforce oAauth application has been set up with the Proof Key for Code Exchange (PKCE) Extension enabled. This doesn't appear to be supported by this plugin. We may not be able to disable this though as it can be required at an organisation level. 

It doesn't look hugely complex to support though so I had a quick attempt. 

Currently, this work is _theoretical_ as I don't actually have a Salesforce account to verify that it works. But this appears to be what is required as per the Salesforce documentation and if we can't just disable this feature, we can look into this further. 

* https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_web_server_flow.htm&type=5
* https://help.salesforce.com/s/articleView?id=sf.remoteaccess_pkce.htm&type=5